### PR TITLE
very simple command class and MoveCmd implementation for use in early game

### DIFF
--- a/OSGame/core/src/com/OSG/OSGame.java
+++ b/OSGame/core/src/com/OSG/OSGame.java
@@ -2,6 +2,9 @@ package com.OSG;
 
 import com.renderer.Drawable;
 import com.map.Map;
+import com.map.Direction;
+import com.comms.Command;
+import com.comms.MoveCmd;
 
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
@@ -14,12 +17,14 @@ public class OSGame extends ApplicationAdapter {
 	Texture img;
 
 	Drawable map;
+	Command example;
 
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
 		img = new Texture("badlogic.jpg");
 		map = new Map();
+		example = new MoveCmd(Direction.NORTH);
 	}
 
 	@Override

--- a/OSGame/core/src/com/comms/Command.java
+++ b/OSGame/core/src/com/comms/Command.java
@@ -1,0 +1,8 @@
+package com.comms;
+
+//abstract commands for input to create and pass through comms to game loop
+public abstract class Command{
+    //this is a class so that we can add implementations here
+    //in the future that are common to all command messages
+    abstract public char[] getData();
+}

--- a/OSGame/core/src/com/comms/Command.java
+++ b/OSGame/core/src/com/comms/Command.java
@@ -1,8 +1,21 @@
 package com.comms;
 
-//abstract commands for input to create and pass through comms to game loop
+/**
+ * abstract class for abstract commands representing the users actions
+ * These are intended to be constructed by the input system 
+ * then tranported by the comms system before being sent to the
+ * main game logic loop to process
+ * @author Brett Menzies
+ */
 public abstract class Command{
-    //this is a class so that we can add implementations here
-    //in the future that are common to all command messages
+    /**
+     * Returns all the data necessary to describe itself in a compact format
+     * for the comms system. 
+     * 
+     * Eventually we might have a "claim data"
+     * method that will parse a char array and return true if this
+     * class made it. Just an idea though.
+     *
+     */
     abstract public char[] getData();
 }

--- a/OSGame/core/src/com/comms/MoveCmd.java
+++ b/OSGame/core/src/com/comms/MoveCmd.java
@@ -2,9 +2,19 @@ package com.comms;
 
 import com.comms.Command;
 import com.map.Direction;
-
+/**
+ * This represents user commands for moving in a cardinal direction
+ *
+ * @author Brett Menzies
+ */
 public class MoveCmd extends Command{
     private Direction dir;
+    /**
+     * This represents user commands for moving in a cardinal direction
+     * 
+     * @param direction     The directon the user wishes to move in
+     *                      can take value NORTH, EAST, SOUTH, or WEST
+     */
     public MoveCmd(Direction direction){
         dir = direction;
     }

--- a/OSGame/core/src/com/comms/MoveCmd.java
+++ b/OSGame/core/src/com/comms/MoveCmd.java
@@ -1,0 +1,21 @@
+package com.comms;
+
+import com.comms.Command;
+import com.map.Direction;
+
+public class MoveCmd extends Command{
+    private Direction dir;
+    public MoveCmd(Direction direction){
+        dir = direction;
+    }
+    public Direction getDirection(){
+        return dir;
+    }
+    public char[] getData(){
+        char[] out = new char[1];
+        if(dir != null){
+            out[0] = dir.toChar();   
+        }
+        return out;
+    }
+}

--- a/OSGame/core/src/com/map/Direction.java
+++ b/OSGame/core/src/com/map/Direction.java
@@ -1,0 +1,11 @@
+package com.map;
+
+public enum Direction{
+    NORTH((char) 0), 
+    EAST ((char) 1),
+    SOUTH((char) 2), 
+    WEST ((char) 3);
+    private char i;
+    Direction(char val){ this.i = val; }
+    public char toChar(){ return i; }
+}

--- a/OSGame/core/src/com/map/Direction.java
+++ b/OSGame/core/src/com/map/Direction.java
@@ -1,5 +1,9 @@
 package com.map;
-
+/**
+ * Enum representing all the valid cardinal directions in the map
+ *
+ * @author Brett Menzies
+ */
 public enum Direction{
     NORTH((char) 0), 
     EAST ((char) 1),
@@ -7,5 +11,9 @@ public enum Direction{
     WEST ((char) 3);
     private char i;
     Direction(char val){ this.i = val; }
+    /**
+     * This provides an easy way for the enum to describe itself to commands
+     * and the comm system
+     */
     public char toChar(){ return i; }
 }


### PR DESCRIPTION
A Direction enum was added to the map package for MoveCmd to describe itself with

A pointless command object is constructed in OSGame as an example

The network code seems to want a string/array of chars for transmission, so the Command class provides a "getData" returning a freshly constructed array of chars.
