### PR TITLE
Junit for command line

### DIFF
--- a/OSGame/build.gradle
+++ b/OSGame/build.gradle
@@ -46,9 +46,11 @@ project(":core") {
 
 
     dependencies {
+        compile "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
+        testCompile group: 'junit', name: 'junit', version: '4.12'
     }
 }
 

--- a/OSGame/core/build.gradle
+++ b/OSGame/core/build.gradle
@@ -3,9 +3,13 @@ apply plugin: "java"
 sourceCompatibility = 1.6
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-sourceSets.main.java.srcDirs = [ "src/" ]
-
+sourceSets.main.java.srcDirs = [ "src/com" ]
+test.testSrcDirs = [ "src/test" ]
 
 eclipse.project {
     name = appName + "-core"
+}
+
+dependencies {
+  testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/OSGame/core/build.gradle
+++ b/OSGame/core/build.gradle
@@ -4,12 +4,21 @@ sourceCompatibility = 1.6
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/com" ]
-test.testSrcDirs = [ "src/test" ]
+sourceSets.test.java.srcDirs = [ "src/test" ]
+
+test {
+    useJUnit()
+    testLogging {
+        // Show that tests are run in the command-line output
+        showStandardStreams = true
+        events 'passed'
+    }
+}
 
 eclipse.project {
     name = appName + "-core"
 }
 
 dependencies {
-  testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
Command line users should be able to run the unit testes with "gradle test" now, and problems with the unit tests will not affect the compilation of the regular source.

master hasn't been compiling (for me at least) because A: the compile path included the test folder and B: the compileJava class didn't depend on JUnit

So now normal "compileJava" and "run" tasks don't care about the test folder, but the "test" task will download junit, run every method with "@test" within src/test/ and report the results. It also echoes the tests stdout and stderr so we can see that (by default it doesn't).
